### PR TITLE
Remove context window dependency

### DIFF
--- a/flib/models/ollama.py
+++ b/flib/models/ollama.py
@@ -6,22 +6,10 @@ from warnings import warn
 from flib.utils.images import encode_image_base64
 from .base import BaseModel
 
-MODEL_NAME_TO_CONTEXT_WINDOW_TOKEN_SIZE = {
-    "mistral": 4096,
-}
-
-MODEL_NAME_TO_EMBEDDING_VECTOR_SIZE = {
-    "mistral": 4096,
-}
-
-
 class OllamaModel(BaseModel):
     def __init__(self, model_name: str):
         ollama.pull(model_name)
         self.model_name = model_name
-        self.context_window_token_size = MODEL_NAME_TO_CONTEXT_WINDOW_TOKEN_SIZE[
-            model_name
-        ]
 
     def run(self, prompt: str, temperature: float = 0.0) -> str:
         if temperature != 0:
@@ -50,7 +38,6 @@ class OllamaEmbeddingModel(BaseModel):
     def __init__(self, model_name: str):
         ollama.pull(model_name)
         self.model_name = model_name
-        self.embedding_vector_size = MODEL_NAME_TO_EMBEDDING_VECTOR_SIZE[model_name]
 
     def run(self, prompt: str) -> list[float]:
         return ollama.embeddings(model=self.model_name, prompt=prompt)["embedding"]

--- a/flib/models/openai.py
+++ b/flib/models/openai.py
@@ -7,18 +7,6 @@ from flib.utils.images import encode_image_base64
 from flib.utils.parallel import ParallelTqdm
 from .base import BaseModel
 
-MODEL_NAME_TO_CONTEXT_WINDOW_TOKEN_SIZE = {
-    "gpt-3.5-turbo": 4096,
-    "gpt-4-turbo": 128000,
-    "gpt-4o": 128000,
-    "gpt-4o-mini": 128000,
-    "o1-mini": 128000,
-}
-
-MODEL_NAME_TO_EMBEDDING_VECTOR_SIZE = {
-    "text-embedding-3-small": 1536,
-}
-
 
 class OpenAIGPTModel(BaseModel):
     def __init__(self, model_name: str, api_key: str):

--- a/flib/models/openai.py
+++ b/flib/models/openai.py
@@ -24,9 +24,6 @@ class OpenAIGPTModel(BaseModel):
     def __init__(self, model_name: str, api_key: str):
         self.model_name = model_name
         self.client = OpenAI(api_key=api_key)
-        self.context_window_token_size = MODEL_NAME_TO_CONTEXT_WINDOW_TOKEN_SIZE[
-            model_name
-        ]
 
     def run(
         self, prompt: str, images: (None | list[Image.Image]) = None, temperature: float = 0.0


### PR DESCRIPTION
As suggested in the title, this PR removes all references to the context window size, which only serves as an attribute of the models, but isn't really flexible when new models (names) come out.